### PR TITLE
kubernetes-setup: Update API to v1beta2

### DIFF
--- a/kubernetes-setup/files/kubeadm_config.yaml
+++ b/kubernetes-setup/files/kubeadm_config.yaml
@@ -1,9 +1,9 @@
-apiVersion: kubeadm.k8s.io/v1beta1
+apiVersion: kubeadm.k8s.io/v1beta2
 kind: InitConfiguration
 nodeRegistration:
   criSocket: "unix:///var/run/crio/crio.sock"
 ---
-apiVersion: kubeadm.k8s.io/v1beta1
+apiVersion: kubeadm.k8s.io/v1beta2
 kind: ClusterConfiguration
 networking:
   podSubnet: "10.85.0.0/16"


### PR DESCRIPTION
Kubernetes packages for Fedora 32 updated some APIs to v1beta2.

Trying to use deprecated API v1beta1, throws the following errors:

    W0827 13:40:20.932549   12653 common.go:77] your configuration file uses a deprecated API spec: "kubeadm.k8s.io/v1beta1". Please use 'kubeadm config migrate --old-config old.yaml --new-config new.yaml', which will write the new, similar spec using a newer API version.
    W0827 13:40:21.462455   12653 configset.go:348] WARNING: kubeadm cannot validate component configs for API groups [kubelet.config.k8s.io kubeproxy.config.k8s.io]

Signed-off-by: Murilo Opsfelder Araujo <muriloo@linux.ibm.com>