### PR TITLE
kubernetes-setup: Add support for kata

### DIFF
--- a/kubernetes-setup/README.md
+++ b/kubernetes-setup/README.md
@@ -36,3 +36,11 @@ To setup a worker node:
 ```
 ansible-playbook -i inventory main.yaml --skip-tags "kubeadm_init"
 ```
+
+To setup a single node cluster for kata developement:
+```
+sed -i -e 's/TaintedNode: no/TaintedNode: yes/' \
+       -e 's/SetupKataContainers: no/SetupKataContainers: yes/' \
+       main.yaml
+ansible-playbook -i inventory main.yaml
+```

--- a/kubernetes-setup/files/50-kata
+++ b/kubernetes-setup/files/50-kata
@@ -1,0 +1,12 @@
+[crio.runtime]
+manage_ns_lifecycle = true
+
+[crio.runtime.runtimes.runc]
+runtime_path = ""
+runtime_type = "oci"
+runtime_root = "/run/runc"
+
+[crio.runtime.runtimes.kata]
+runtime_path = "/usr/bin/containerd-shim-kata-v2"
+runtime_type = "vm"
+runtime_root = "/run/vc"

--- a/kubernetes-setup/files/kata_runtimeclass.yaml
+++ b/kubernetes-setup/files/kata_runtimeclass.yaml
@@ -1,0 +1,9 @@
+kind: RuntimeClass
+apiVersion: node.k8s.io/v1beta1
+metadata:
+  name: kata
+handler: kata
+overhead:
+  podFixed:
+    memory: "160Mi"
+    cpu: "250m"

--- a/kubernetes-setup/main.yaml
+++ b/kubernetes-setup/main.yaml
@@ -4,7 +4,8 @@
   hosts: all
   become: yes
   vars:
-    HOME: /home/fedora
+    User: fedora
+    HOME: "/home/{{ User }}"
     UpdateAllRPMs: no
     F32:
       - bash-completion
@@ -129,3 +130,29 @@
       tags:
         - kubeadm_init
     - debug: var=debug_kubeadm_init.stdout_lines
+
+    - name: Create {{ HOME }}/.kube for {{ User}}
+      file:
+        path: "{{ HOME }}/.kube"
+        state: directory
+      tags:
+        - kubeadm_init
+
+    # This is ugly, but when using the copy module I've faced some issues related to permissions.
+    - name: Copy the Kubernetes configuration file for {{ User }}
+      shell: cp -i /etc/kubernetes/admin.conf {{ HOME }}/.kube/config && chown {{ User }}:{{ User }}/.kube -R
+      tags:
+        - kubeadm_init
+
+    - name: Create ~/.kube for root
+      file:
+        path: ~/.kube
+        state: directory
+      tags:
+        - kubeadm_init
+
+    # This is ugly, but when using the copy module I've faced some issues related to permissions.
+    - name: Copy the Kubernetes configuration file for root
+      shell: cp -i /etc/kubernetes/admin.conf ~/.kube/config
+      tags:
+        - kubeadm_init

--- a/kubernetes-setup/main.yaml
+++ b/kubernetes-setup/main.yaml
@@ -8,6 +8,7 @@
     HOME: "/home/{{ User }}"
     UpdateAllRPMs: no
     TaintedNode: no
+    SetupKataContainers: no
     F32:
       - bash-completion
       - git
@@ -163,3 +164,48 @@
       when: TaintedNode
       tags:
         - tainted_node
+
+    - name: Install Kata Containers packages
+      dnf:
+        name: kata-runtime
+        state: present
+      when: SetupKataContainers
+      tags:
+        - kata_containers
+
+    - name: Create the kata runtime class
+      shell: kubectl apply -f {{ playbook_dir }}/files/kata_runtimeclass.yaml
+      when: SetupKataContainers
+      tags:
+        - kata_containers
+
+    - name: Create /etc/crio/crio.conf.d/
+      file:
+        path: /etc/crio/crio.conf.d
+        state: directory
+        owner: root
+        group: root
+        mode: '0755'
+      when: SetupKataContainers
+      tags:
+        - kata_containers
+
+    - name: Create the CRI-O drop-in file for Kata Containers
+      copy:
+        src: "{{ playbook_dir }}/files/50-kata"
+        dest: /etc/crio/crio.conf.d/50-kata
+        owner: root
+        group: root
+        mode: '0644'
+      when: SetupKataContainers
+      tags:
+        - kata_containers
+
+    - name: Restart CRI-O service
+      systemd:
+        state: restarted
+        daemon_reload: yes
+        name: cri-o
+      when: SetupKataContainers
+      tags:
+        - kata_containers

--- a/kubernetes-setup/main.yaml
+++ b/kubernetes-setup/main.yaml
@@ -7,6 +7,7 @@
     User: fedora
     HOME: "/home/{{ User }}"
     UpdateAllRPMs: no
+    TaintedNode: no
     F32:
       - bash-completion
       - git
@@ -156,3 +157,9 @@
       shell: cp -i /etc/kubernetes/admin.conf ~/.kube/config
       tags:
         - kubeadm_init
+
+    - name: Allow scheduling Pods on the control-plane node
+      shell: kubectl taint nodes --all node-role.kubernetes.io/master-
+      when: TaintedNode
+      tags:
+        - tainted_node


### PR DESCRIPTION
This series adds support for creating an environment that can be easily used for playing, debugging, and developing for kata-containers on a single node k8s cluster.